### PR TITLE
update Rez and SetFile paths

### DIFF
--- a/eulagise.pl
+++ b/eulagise.pl
@@ -42,10 +42,10 @@ my(@gCleanup, %gConfig, $gDarwinMajor, $gDryRun, $gVerbosity);
             'cmd_hdiutil'        => 'hdiutil',
             'cmd_mkdir'          => 'mkdir',
             'cmd_mktemp'         => 'mktemp',
-            'cmd_Rez'            => '/Applications/Xcode.app/Contents/Developer/Tools/Rez',
+            'cmd_Rez'            => '/usr/bin/Rez',
             'cmd_rm'             => 'rm',
             'cmd_rsync'          => 'rsync',
-            'cmd_SetFile'        => '/Applications/Xcode.app/Contents/Developer/Tools/SetFile',
+            'cmd_SetFile'        => '/usr/bin/SetFile',
 
             # create_directly indicates whether hdiutil create supports
             # -srcfolder and -srcdevice.  It does on >= 10.3 (Panther).


### PR DESCRIPTION
By default on new versions of MacOS Rez and SetFile are installed
in /usr/bin instead of
/Applications/Xcode.app/Contents/Developer/Tools/