### PR TITLE
Fix Rez command for newer macOS version by specifying path to Frameworks containing Carbon.r

### DIFF
--- a/eulagise.pl
+++ b/eulagise.pl
@@ -252,7 +252,7 @@ if(@resourceFiles) {
   # removing $targetImage anyway.
 
   # Type definitions come from Carbon.r.
-  if(command($gConfig{'cmd_Rez'}, 'Carbon.r', @resourceFiles, '-a', '-o',
+  if(command($gConfig{'cmd_Rez'}, '-F', '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/', 'Carbon.r', @resourceFiles, '-a', '-o',
    $targetImage) != 0) {
     cleanupDie('Rez failed');
   }


### PR DESCRIPTION
After updating my mac, eulagise was failing with the following error when calling Rez:
```
/usr/bin/Rez Carbon.r pkg-dmg.64915.nBMbD5fY/license.r -a -o app.dmg
failed to find Carbon/Carbon.r
### Rez - noErr (0) during open of "Carbon.r".
Fatal Error!
### Rez - Fatal Error, can't recover.
Carbon.r: ### Rez - Since errors occurred, app.dmg's resource fork was not completely updated.
../eulagise.pl: Rez failed (cleaning up)
```

I've found [here](https://wiki.bolay.net/doku.php?id=acdsn:acdsn-a:mac) that specifying the Frameworks path helps.
Hopefully, since the path in my patch doesn't include any version number, it should on future versions of macOS (unless Frameworks path changes).